### PR TITLE
fixed error for undefined variable

### DIFF
--- a/block_simple_nav.php
+++ b/block_simple_nav.php
@@ -289,7 +289,8 @@ class block_simple_nav extends block_base {
         
         foreach ($allmodules as $module) {
             $show_mods_frontpage = 'show_mods_frontpage_' . $module->name;
-            
+            $mods_value_frontpage = null;
+
             if (!empty($this->config)) {
                 // we check here if there is a valid property available in the config-file for a
                 // specific module


### PR DESCRIPTION
We were having the following errors on our site.

PHP Notice: Undefined variable: mods_value_frontpage in /var/www/html/blocks/simple_nav/block_simple_nav.php on line 308, referer: http://staging.onlinecampus.getsmarter.ac/login/index.php

I've set the $mods_value_frontpage to a default value so this error stops

